### PR TITLE
Update layer pins for 2018-03-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To remove the shared state for a component as well as its build artifacts to ens
     $ make cleanall-<component-name>
 
 ### Adding new layers
-The script automates the process of adding new OE layers to the build environment.  The information required for integrate new layer are; layer name, OE priority, repository, identification in the form branch, commit or tag ids. It is also possible to reference a layer from local storage area.  The details are documented in weboslayers.py.
+The script automates the process of adding new OE layers to the build environment.  The information required for integrating a new layer is: layer name, OE priority, repository, identification in the form branch, commit or tag ids. It is also possible to reference a layer from local storage area.  The details are documented in weboslayers.py.
 
 
 

--- a/weboslayers.py
+++ b/weboslayers.py
@@ -68,17 +68,17 @@ webos_layers = [
 ('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    '', 'meta-oe'),
 ('meta-filesystems',          14, 'git://github.com/openembedded/meta-openembedded.git',    '', 'meta-oe'),
 
-('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 'branch=krogoth,commit=dcfcb58', ''),
+('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 'branch=krogoth,commit=f8584d7', ''),
 
 ('meta-webos-backports-2.3',  30, 'git://github.com/webosose/meta-webosose.git',            '', ''),
 ('meta-webos-backports-2.4',  31, 'git://github.com/webosose/meta-webosose.git',            '', ''),
 ('meta-webos-backports-2.5',  32, 'git://github.com/webosose/meta-webosose.git',            '', ''),
 ('meta-webos-backports-2.6',  33, 'git://github.com/webosose/meta-webosose.git',            '', ''),
 
-('meta-webos',                40, 'git://github.com/webosose/meta-webosose.git',            'branch=master,commit=f8882e8', ''),
+('meta-webos',                40, 'git://github.com/webosose/meta-webosose.git',            'branch=master,commit=b34522f', ''),
 
 ('meta-raspberrypi',          50, 'git://git.yoctoproject.org/meta-raspberrypi',            'branch=morty,commit=2a19226', ''),
 ('meta-webos-raspberrypi',    51, 'git://github.com/webosose/meta-webosose.git',            '', ''),
 ('meta-ros2',                 52, 'git://github.com/lgsvl/meta-ros2.git',                   'branch=devel,commit=ccde307', ''),
-('meta-ros2-lgsvl',           60, 'git://github.com/lgsvl/meta-ros2-lgsvl.git',             'branch=devel,commit=505fd42', ''),
+('meta-ros2-lgsvl',           60, 'git://github.com/lgsvl/meta-ros2-lgsvl.git',             'branch=devel,commit=d28e3e7', ''),
 ]


### PR DESCRIPTION
meta-ros2-lgsvl:
  d28e3e7 Add missing lifecycle-msgs dependencies (#11)
  b14524f Fix boost build time dependency on python (#10)

Move meta-qt5 and meta-webos back from OSE build #9 as LSM made
WEBOS_COMPOSITOR_{WIDTH,HEIGHT} obsolete by
https://github.com/webosose/luna-surfacemanager/commit/4c8059cd5c8b9225c7f1b4044bf76d092d1aa8a7#diff-1392a2f0ecb082b7133520b6b20dea37

So when moving forward to build #9 and applying these again:
  - webos-image: meta-qt5 upgrade to 5.6.3 (build 9 1/2)
  - webos-image: Update layer pins for 2018-07-13 (build 9 2/2)
this needs to be reworked:
https://github.com/lgsvl/meta-ros2-lgsvl/commit/9024b9b649c5c28ca21c6eba89d2e8240dc21eeb