### PR TITLE
Teach mcf on BblayersConfExtraLines to support future meta-ros

### DIFF
--- a/mcf
+++ b/mcf
@@ -25,7 +25,7 @@ from time import gmtime, strftime, sleep
 import shutil
 import glob
 
-__version__ = "6.2.3"
+__version__ = "6.2.3a"
 
 logger = logging.getLogger(__name__)
 
@@ -462,6 +462,12 @@ def write_bblayers_conf(sourcedir):
         f.write(bblayers)
         f.write('"\n')
         f.write(priorities)
+        try:
+            from weboslayers import BblayersConfExtraLines
+            if BblayersConfExtraLines:
+                f.writelines('\n' + '\n'.join(BblayersConfExtraLines) + '\n')
+        except ImportError:
+            pass
 
 def update_layers(sourcedir):
     logger.info('MCF-%s: Updating build directory' % __version__)

--- a/mcf
+++ b/mcf
@@ -25,7 +25,7 @@ from time import gmtime, strftime, sleep
 import shutil
 import glob
 
-__version__ = "6.2.2"
+__version__ = "6.2.3"
 
 logger = logging.getLogger(__name__)
 
@@ -644,7 +644,7 @@ def reposanitycheck(layer):
             if not trackingbranch or not trackingremote or trackingbranch.replace('refs/heads',trackingremote) != remotebranch:
                 logger.warn("checkout %s was tracking '%s/%s' changing it to track '%s'" % (layer["location"], trackingremote, trackingbranch, remotebranch))
                 # to ensure we are tracking remote
-                echo_check_call('git branch --set-upstream %s %s' % (newbranch, remotebranch))
+                echo_check_call('git branch %s --set-upstream-to %s' % (newbranch, remotebranch))
 
         elif not foundlocalbranch and remotebranch:
             echo_check_call('git checkout -b %s %s' % (newbranch, remotebranch))

--- a/weboslayers.py
+++ b/weboslayers.py
@@ -82,3 +82,6 @@ webos_layers = [
 ('meta-ros2',                 52, 'git://github.com/lgsvl/meta-ros2.git',                   'branch=devel,commit=ccde307', ''),
 ('meta-ros2-lgsvl',           60, 'git://github.com/lgsvl/meta-ros2-lgsvl.git',             'branch=devel,commit=d28e3e7', ''),
 ]
+
+# BblayersConfExtraLines is a tuple of strings to be appended to the generated conf/bblayers.conf.
+BblayersConfExtraLines = ('')


### PR DESCRIPTION
  * Have mcf recognize an optional BblayersConfExtraLines variable in weboslayers.py
    that contains a tuple of strings to be appended as separate lines to the generated
    conf/bblayers.conf .
  * See https://github.com/lgsvl/superflore/wiki/Proposed-Superflore-OE-Recipe-Generation-Scheme
  * As per MartinJ, "mcf(s) are independent. I was keeping the version numbers \
    and features in sync across SVL build-* repos. When there was some change \
    only for some of them then it was implemented in version ending with some letter"
  * Sync mcf to latest version used in build-webos